### PR TITLE
Fix bug in line 30 of mcr.sh

### DIFF
--- a/mcr.sh
+++ b/mcr.sh
@@ -27,7 +27,7 @@ echo "enter the number of addresses you want to read thier content:"
 read num
 if [ -s ./meltdown.out ]
 then
-if [ `sudo ./meltdown.out $meltdown_addr $num` ]
+if ! sudo ./meltdown.out $meltdown_addr $num > /dev/null
 then
 uname -rvi
 head /proc/cpuinfo


### PR DESCRIPTION
Fixes script outputting `./mcr.sh: line 30: [: too many arguments`